### PR TITLE
Update csgo-server-launcher.sh

### DIFF
--- a/csgo-server-launcher.sh
+++ b/csgo-server-launcher.sh
@@ -149,7 +149,7 @@ function update {
   # restore motd.txt
   mv $DIR_GAME/csgo/motd.txt.bck $DIR_GAME/csgo/motd.txt
   
-  if [ `egrep -ic "Success! App '740' fully installed." "$UPDATE_LOG"` -gt 0 ]
+  if [ `egrep -ic "Success! App '740' fully installed." "$UPDATE_LOG"` -gt 0 ]]||[ `egrep -ic "Success! App '740' already up to date" "$UPDATE_LOG"` -gt 0 ]
   then
     echo "$SCREEN_NAME updated successfully"
   else


### PR DESCRIPTION
Correction in case CSGO update is not necessary because files are uptodate. Else it enters a neverending loop that has stopped server.
