### PR TITLE
Fix hosts with an IPv6 address failing on getting own ip address

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ If you are interested, [check out](https://hub.docker.com/r/crazymax/) my other 
 
 And also the following environment variables to edit the CSGO Server Launcher [configuration](https://github.com/crazy-max/csgo-server-launcher/wiki/Configuration) :
 
-* `IP` (default `$(sudo dig +short myip.opendns.com @resolver1.opendns.com)`)
+* `IP` (default `$(sudo dig -4 +short myip.opendns.com @resolver1.opendns.com)`)
 * `GSLT`
 * `STEAM_LOGIN` (default `anonymous`)
 * `STEAM_PASSWORD` (default `anonymous`)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ SSMTP_PORT=${SSMTP_PORT:-25}
 SSMTP_HOSTNAME=${SSMTP_HOSTNAME:-$(hostname -f)}
 SSMTP_TLS=${SSMTP_TLS:-NO}
 
-IP=${IP:-$(sudo dig +short myip.opendns.com @resolver1.opendns.com)}
+IP=${IP:-$(sudo dig -4 +short myip.opendns.com @resolver1.opendns.com)}
 GSLT=${GSLT}
 STEAM_LOGIN=${STEAM_LOGIN:-anonymous}
 STEAM_PASSWORD=${STEAM_PASSWORD:-anonymous}

--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ scriptPath="/etc/init.d/$scriptName"
 confPath="/etc/csgo-server-launcher/csgo-server-launcher.conf"
 steamcmdPath="/var/steamcmd"
 user="steam"
-ipAddress=$(dig +short myip.opendns.com @resolver1.opendns.com)
+ipAddress=$(dig -4 +short myip.opendns.com @resolver1.opendns.com)
 if [ -z "$ipAddress" ]; then
   echo "ERROR: Cannot retrieve your public IP address..."
   exit 1


### PR DESCRIPTION
`dig +short myip.opendns.com @resolver1.opendns.com` in install.sh returns empty on hosts with an IPv6 address available; addding `-4` to the arguments to force IPv4 fixes this.